### PR TITLE
Add External DNS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 *.sublime-workspace
 
 # Personal directories
+credentials
 keys
 scratch

--- a/README.md
+++ b/README.md
@@ -11,16 +11,26 @@
 - Maximize code reuse, minimize service directory size and complexity
 
 ## Setup
-Run `tilt up`
- 
-or run `docker-compose up`
+Change the domain to your target domain in these files: 
+- [Domain Filter in external-dns service](./services/external-dns/k8s.yaml)
+- [Hostname annotation in web-frontend service](./services/web-frontend/k8s.yaml)
+- [REACT_APP_HOST in web-frontend dockerfile](./services/web-frontend/Dockerfile)
+- [TiltHost in public-api service](./services/public-api/constants/constants.go)
 
-and navigate to `localhost` (no port). 
+Follow [`external-dns` instructions](./services/external-dns/README.md) if you intend to use it.
+
+Run `tilt up` 
+
+and navigate to your target domain (no port). 
+
+You can also run the services via `docker-compose up`, individually via dockerfile, or in terminal.
 
 ## Services: 
+- [External DNS](./services/external-dns/README.md)
 - [Web Frontend Service](./services/web-frontend/src/components/README.md)
 - [Public API Service](./services/public-api/README.md)
 - [Postgres API Store](./services/api-store/README.md)
+- [Example GRPC Service](./services/grpc)
 
 ## Docs
 - [TODO](./TODO.md)

--- a/TODO.md
+++ b/TODO.md
@@ -3,27 +3,11 @@
 ## Table of Contents 
 - [Tasks](#todo)
 - [Backlog](#backlog)
-- [Known Unknowns](#known-unknowns)    
-- [Answered](#answered)   
+- [Known Unknowns](#known-unknowns)      
 - [Completed](#completed)
 
-## Tasks 
-From highest priority to lowest.
-UI: 
-- [ ] Mapping Actions to Transformations 
-- [ ] Mapping UI to Actions 
-- [ ] Managing requests from multiple Panes
-    - [ ] Likely need a mapping between pane and content 
-- [ ] Panes -- iterm-like UI that maps to some local storage 
-- [ ] Sidebar 
-- [ ] Top-bar 
-- [ ] Account 
-- [ ] Frontend Redux Testin
-- [ ] Clean up directory structure
-
-Puzzles: 
-- [ ] Doc chunking design 
-- [ ] Transformations and Sourcegraph Data Structure 
+Unordered Tasks: 
+- [ ] Fix go mod pathing
 
 Architecture: 
 - [ ] Connection/ConnectionFactory interface 
@@ -42,12 +26,6 @@ Environment:
 - [ ] Envoy (https://www.envoyproxy.io/)
 
 Public-API: 
-- [x] Cleaner client connection creation 
-- [ ] Move Handler-Controller-Connection to libraries 
-    need to pass in store information at beginning, if provided then connection is initialized. 
-    alternatively could move out a copy and play there 
-    need to imagine what this would look like and how complex it is. Upside is that there would a common way of init-ing golang services 
-    downside is "one-size fits all". Requires better layered interface before moving it out into an external library.
 - [ ] Health endpoint (https://blog.gopheracademy.com/advent-2017/kubernetes-ready-service/)
 - [ ] Graceful shutdown (https://blog.gopheracademy.com/advent-2017/kubernetes-ready-service/)
 - [ ] Request JSON-to-Struct Mapping
@@ -61,12 +39,12 @@ Public-API:
 - [ ] API Service Error Handling 
 - [ ] API Service Logging
 
-Deployment: 
-- [ ] Running kubernetes-orchestrated cluster
+K8s/Deployment: 
+- [ ] Testing Public Zone for frontend 
+- [ ] Switch to port 443 for frontend 
 - [ ] Per-commit automated deployments 
 
 Other: 
-- [ ] Chrome extension to extract and import text 
 - [ ] Clean up READMEs 
 
 ## Backlog
@@ -78,74 +56,17 @@ Other:
 - [ ] Redis: Map session id to cached chunks 
 
 ## Known Unknowns
-- What would it take to make a MVP? 
-    - Necessary:
-        - Login 
-        - Base Set of Transformations
-        - Transformations have corresponding Actions 
-        - Start off 
-        - Create doc 
-    - Not:
-        - Actions/UI (that are graphdocs themselves)
-        - Chunking 
-        - Silos
-        - Forums  
-    - Ideas: 
-        - Initial version would be stored persistently in volume and you use it with tilt up <-- love it 
-- How can scopes express collections of other scopes? Or should that involve a separate abstraction? 
-- Data preprocessing is extremely expensive for ML models. This is a known opportunity. How can sourcegraph be organized to act as a foundation for ML models? 
-- Is it possible to produce end-documents from scopes describing scopes? 
-- Parent-child scopes? Ex: document scope vs chapter scope. Should the chapter scope exist within the document? How should scopes be linked? 
-- What dictates whether two scopes can interact? An overlap in transformations?
-- How to properly use Neo4j? 
 
-## Answered
-- Should the UI interface also be a sourcegraph? 
-    - Yes, but not initially, initially just open source the project, but make clean abstractions that you can easily iterate on 
-- Should go mod be initialized in each golang service, as opposed in the root ./sg directory?
-    - Yup, each service has it's own so it can dockerize individually 
-- How to identify copies? 
-    - Large files are red flag
-- How to make actions and transformations into graph-docs? 
-    - Initially don't, turn to open-source first, and then as you have more resources make the transition, in the intervening time prepare a space for it, think about it
-- UI/Actions/Transformation relationship? 
-    - Action should take a transformation, funct(funct), UI should be a collection of Actions(Transformations) that are applied as a method 
-- What is an efficient way to apply all the sources to find the current state of a doc?
-    - Separate service. Separate service is responsible for 
-- How to offer different UI interfaces? 
-    - This is where Mike's approach may be easier, having allowing other websites. 
-    - Middleground is allowing plugins. 
-- Where do metrics fit into the social abstractions? 
-    - Metrics are for credibility. Credibility is tied to trust. Trust is tied to silos.
-- Examples of metrics: 
-    - Minimum and maximum metrics: memberships and awards.
-- Should scopes have to be owned by a silo? 
-    - Yes. 
-- Can scopes be able to change owners? 
-    - No. Creator-status is involiable. 
-- Scope vs overlay? 
-    Scope is chain of transformations. Overlay are "surrounding" documents that reference _it_.     
-- Should faceted identities be allowed to own multiple silos?
-    - Each faceted identity should have its own personal silo. 
-    - I see no downside in allowing multiple personal silos for a faceted identity. 
-    - I see no downside in allowing a single silow for all a person's faceted identity. 
-- Should multiple silos be able to own one scope? 
-    - No. Fork the scope for the other silo. 
-- When should a document be saved? Should it be explicit based on pressing publish button or should it be implicit via auto-saves? 
-    - Explicit. I like picturing sourcegraph as an IDE. Whenever command-S is pressed the current diff is saved as a source.
-- Should it be possible to decouple an edge and source? Is there any use-value to that? 
-    - An edge is a transformation. To produce the end-document it's necessary. Edges are necessary at the scope-level. Sources can be self-contained and still be meaningful
-- Should it be possible to delete history?
-    - No, only soft deletions are allowed.  
-- Should a starting scope function take an empty argument? 
-    - Yes, initial doc should be null.  
-- Should one silo be allowed to own another silo? Ex: a company vs team. 
-    - It should be a feature but by default an organization should be like a microservice - interdepedent but decoupled. 
-- Default silos? 
-    - History of read/writes
 
 ## Completed
 From most recent to oldest.
+- [x] Cleaner client connection creation 
+- [x] Move Handler-Controller-Connection to libraries 
+    need to pass in store information at beginning, if provided then connection is initialized. 
+    alternatively could move out a copy and play there 
+    need to imagine what this would look like and how complex it is. Upside is that there would a common way of init-ing golang services 
+    downside is "one-size fits all". Requires better layered interface before moving it out into an external library.
+- [x] Running kubernetes-orchestrated cluster
 - [x] Wire ctx through public-api
 - [x] Tilt Setup: 
     - [x] Convert docker-compose over

--- a/Tiltfile
+++ b/Tiltfile
@@ -9,7 +9,8 @@ services = {
     "api-store": False,
     "grpc": True,
     "public-api": True,
-    "web-frontend": True
+    "web-frontend": True,
+    "external-dns": False
 }
 
 for s in services.keys():
@@ -25,5 +26,5 @@ k8s_resource('api-store')
 k8s_resource('grpc')
 k8s_resource('public-api', resource_deps=['api-store', 'grpc'])
 k8s_resource('web-frontend', resource_deps=['public-api'])
-
+k8s_resource('external-dns', resource_deps=['web-frontend'])
 

--- a/services/external-dns/README.md
+++ b/services/external-dns/README.md
@@ -30,7 +30,7 @@ To enable External DNS to modify records we will need to associate an IAM policy
 }
 ```
 2. Make AWS IAM user using this policy. 
-3. Locally run: `kubectl create secret generic test-secret --from-literal=AWS_ACCESS_KEY_ID='< access key id >' --from-literal=AWS_SECRET_ACCESS_KEY='< access key >'` using the credential info of this user. `envFrom.secretRef` will pick up on this key and run as the user.  
+3. Locally run: `kubectl create secret generic test-secret --from-literal=AWS_ACCESS_KEY_ID='< access key id >' --from-literal=AWS_SECRET_ACCESS_KEY='< access key >' --from-literal=AWS_HOSTED_ZONE_ID='< your target hosted zone id >'` using the credential info of this user. `envFrom.secretRef` will pick up on this key and run as the user.  
 4. Update the `--domain-filter` and `external-dns.alpha.kubernetes.io/hostname` to whatever the hostname of the hosted zone is. 
 
  

--- a/services/external-dns/README.md
+++ b/services/external-dns/README.md
@@ -1,0 +1,36 @@
+# External DNS 
+
+## What is External DNS? 
+External DNS manages your provider's Hosted Zone. A Hosted Zone maps a domain to name servers and serves DNS records. External DNS modifies these DNS to be pointing to specific k8s Service IP. 
+
+In our case we set `--domain-filter=< domain >` and `--txt-owner-id=< hosted zone id >` so that external dns manages the specified hosted zone and associates it to services with matching domain. In the web-frontend service  we set `external-dns.alpha.kubernetes.io/hostname` to `www.grouphouse.io` for its target domain and the filter picks up on this value so that the records are mapped to the web-frontend service. 
+
+To enable External DNS to modify records we will need to associate an IAM policy via a user or role (I used a user for the time being) so that it can act on behalf of the user or assume the role. 
+
+## Setup 
+1. Define AWS IAM policy to enable external DNS to update the hosted zone records. Replace the hosted zone id. 
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "route53:ChangeResourceRecordSets",
+            "Resource": "arn:aws:route53:::hostedzone/< hosted zone id >"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ListHostedZones",
+                "route53:ListResourceRecordSets"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+2. Make AWS IAM user using this policy. 
+3. Locally run: `kubectl create secret generic test-secret --from-literal=AWS_ACCESS_KEY_ID='< access key id >' --from-literal=AWS_SECRET_ACCESS_KEY='< access key >'` using the credential info of this user. `envFrom.secretRef` will pick up on this key and run as the user.  
+4. Update the `--domain-filter` and `external-dns.alpha.kubernetes.io/hostname` to whatever the hostname of the hosted zone is. 
+
+ 

--- a/services/external-dns/k8s.yaml
+++ b/services/external-dns/k8s.yaml
@@ -32,4 +32,4 @@ spec:
             - --registry=txt
             - --txt-owner-id=AWS_HOSTED_ZONE_ID # your target hosted zone id
             - --txt-prefix=txt. #https://github.com/kubernetes-sigs/external-dns/blob/master/docs/faq.md#im-using-an-elb-with-txt-registry-but-the-cname-record-clashes-with-the-txt-record-how-to-avoid-this
-            - --log-level=debug
+            # - --log-level=debug

--- a/services/external-dns/k8s.yaml
+++ b/services/external-dns/k8s.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+        - name: external-dns
+          image: k8s.gcr.io/external-dns/external-dns:v0.7.6
+          # TODO: Change to using more robust solution than making a local secret:
+          # Command: `kubectl create secret generic test-secret --from-literal=AWS_ACCESS_KEY_ID='< access key id >' --from-literal=AWS_SECRET_ACCESS_KEY='< access key >'`
+          envFrom:
+            - secretRef:
+                name: test-secret
+          args:
+            - --source=service
+            - --source=ingress
+            - --domain-filter=grouphouse.io # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
+            - --provider=aws
+            - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
+            - --aws-zone-type=public # only look at public hosted zones (valid values are public, private or no value for both)
+            - --registry=txt
+            - --txt-owner-id=Z0767399280MTY1FAZPOKx
+            - --txt-prefix=txt. #https://github.com/kubernetes-sigs/external-dns/blob/master/docs/faq.md#im-using-an-elb-with-txt-registry-but-the-cname-record-clashes-with-the-txt-record-how-to-avoid-this
+            - --log-level=debug

--- a/services/external-dns/k8s.yaml
+++ b/services/external-dns/k8s.yaml
@@ -18,7 +18,7 @@ spec:
         - name: external-dns
           image: k8s.gcr.io/external-dns/external-dns:v0.7.6
           # TODO: Change to using more robust solution than making a local secret:
-          # Command: `kubectl create secret generic test-secret --from-literal=AWS_ACCESS_KEY_ID='< access key id >' --from-literal=AWS_SECRET_ACCESS_KEY='< access key >'`
+          # Command: `kubectl create secret generic test-secret --from-literal=AWS_ACCESS_KEY_ID='< access key id >' --from-literal=AWS_SECRET_ACCESS_KEY='< access key >' --from-literal=AWS_HOSTED_ZONE_ID='< your target hosted zone id >'`
           envFrom:
             - secretRef:
                 name: test-secret
@@ -30,6 +30,6 @@ spec:
             - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
             - --aws-zone-type=public # only look at public hosted zones (valid values are public, private or no value for both)
             - --registry=txt
-            - --txt-owner-id=Z0767399280MTY1FAZPOKx
+            - --txt-owner-id=AWS_HOSTED_ZONE_ID # your target hosted zone id
             - --txt-prefix=txt. #https://github.com/kubernetes-sigs/external-dns/blob/master/docs/faq.md#im-using-an-elb-with-txt-registry-but-the-cname-record-clashes-with-the-txt-record-how-to-avoid-this
             - --log-level=debug

--- a/services/public-api/constants/constants.go
+++ b/services/public-api/constants/constants.go
@@ -1,13 +1,11 @@
 package constants
 
-// TODO: How to more tightly couple these values to k8s.yaml? It would be idea to have one
-
 const (
 	MaxConns                  = 40
 	PublicAPIPort             = 8000
 	LocalWebFrontendHost      = "http://localhost:3000"
 	DockerComposeHost         = "http://localhost"
-	TiltHost                  = "http://localhost:8000"
+	TiltHost                  = "http://www.grouphouse.io"
 	SGServiceAddress          = "grpc:8001"
 	APIStoreDriver            = "postgres"
 	APIStorePort              = 5432

--- a/services/web-frontend/Dockerfile
+++ b/services/web-frontend/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /app
 COPY package*.json /app/
 RUN yarn install
 COPY ./ /app/
-# TODO: Confused why localhost works instead of specified ip
-RUN REACT_APP_HOST="localhost" yarn run build
+# HOST can also be "localhost"
+RUN REACT_APP_HOST="www.grouphouse.io" yarn run build
 
 # Stage 1, based on Nginx, to have only the compiled app, ready for production with Nginx
 FROM nginx:1.18

--- a/services/web-frontend/k8s.yaml
+++ b/services/web-frontend/k8s.yaml
@@ -1,4 +1,20 @@
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name:  web-frontend
+  annotations:
+    # Note: if both `www.grouphouse.io, grouphouse.io` is included there's a DNS record naming collision
+    external-dns.alpha.kubernetes.io/hostname: www.grouphouse.io
+spec:
+  type: LoadBalancer
+  selector:
+      app: web-frontend
+  ports:
+    - port: 80
+      name: http
+      targetPort: 80
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -16,19 +32,6 @@ spec:
         - name: web-frontend
           image: web-frontend-image
           imagePullPolicy: Never
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: web-frontend
-  namespace: default
-  labels:
-    app: web-frontend
-spec:
-  type: LoadBalancer
-  selector:
-    app: web-frontend
-  ports:
-    - protocol: "TCP"
-      port: 80
-      targetPort: 80
+          ports:
+            - containerPort: 80
+              name: http


### PR DESCRIPTION
## Terms
External DNS: updates DNS records for a Hosted Zone and a K8s Service. 
Hosted Zone: Cloud Name Servers which point a domain to its associated IP address via DNS records (A and/or CNAME records)  

## What 
On `tilt up` my test hosted zone will be updated and we'll be accessing our domain (`www.grouphouse.io` for now) via public internet name servers, which will redirect us to the correct local address. 

## How 

## Why 
External DNS will be a necessary component of our production environment -- as the IP address of our web-frontend service changes we'll need to ensure that the domain's name servers are promptly updated. It's doubly cool that this feature will work in the dev environment just like it will in production (although down the line we'll need to create a test and prod hosted zone with separate policies). 

## Tasks 

## Notes to Reviewers 

## Meta 