### PR TITLE
Add ingress rules for routing web-frontend and public-api traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,9 @@
 - Maximize code reuse, minimize service directory size and complexity
 
 ## Development Setup
-Run `tilt up` 
+[Apply](https://kubernetes.github.io/ingress-nginx/deploy/#aws) nginx ingress controller so that the ingress rules work. 
 
-and navigate to `localhost` (no port).
-
-You can also run the services via `docker-compose up`, individually via dockerfile, or in terminal.
+Run `tilt up` and navigate to `staging.grouphouse.io`.
 
 ## AWS Deployment
 [Deployment Docs](./deployment/README.md)

--- a/charts/external-dns/README.md
+++ b/charts/external-dns/README.md
@@ -33,4 +33,14 @@ To enable External DNS to modify records we will need to associate an IAM policy
 3. Locally run: `kubectl create secret generic test-secret --from-literal=AWS_ACCESS_KEY_ID='< access key id >' --from-literal=AWS_SECRET_ACCESS_KEY='< access key >' --from-literal=AWS_HOSTED_ZONE_ID='< your target hosted zone id >'` using the credential info of this user. `envFrom.secretRef` will pick up on this key and run as the user.  
 4. Update the `--domain-filter` and `external-dns.alpha.kubernetes.io/hostname` to whatever the hostname of the hosted zone is. 
 
- 
+## Ingress Rules
+
+The Ingress resource is a rule set used for the Ingress Controller to route traffic. 
+
+Without the Ingress Controller the rule cannot be applied. Installation can be found [here](https://kubernetes.github.io/ingress-nginx/deploy/#aws).
+
+There are two ingress resources because _by default_ the ingress controller removed the matching prefix.
+
+Therefore traffic for `/v1/silos` was rewritten to be `/silos`, which is incorrect. 
+
+To retain our current public api prefix/routes a second ingress resource was added with a rewrite rule to include the prefix. 

--- a/charts/external-dns/templates/k8s.yaml
+++ b/charts/external-dns/templates/k8s.yaml
@@ -1,3 +1,48 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web-frontend-rule
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.domain }}
+spec:
+  rules:
+    - host: {{ .Values.domain }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web-frontend
+                port:
+                  number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: public-api-rule
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/rewrite-target: /v$1/$2
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.domain }}
+spec:
+  rules:
+    - host: {{ .Values.domain }}
+      http:
+        paths:
+          - path: /v([0-9])/(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: public-api
+                port:
+                  number: {{ .Values.publicAPIPort }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/grpc/templates/k8s.yaml
+++ b/charts/grpc/templates/k8s.yaml
@@ -32,7 +32,7 @@ metadata:
   labels:
     app: {{ .Values.grpcName }}
 spec:
-  type: LoadBalancer
+  type: NodePort
   ports:
     - port: {{ .Values.grpcPort }}
   selector:

--- a/charts/public-api/templates/k8s.yaml
+++ b/charts/public-api/templates/k8s.yaml
@@ -1,4 +1,19 @@
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: public-api
+  labels:
+    app: public-api
+spec:
+  type: NodePort
+  ports:
+    - port: {{ .Values.publicAPIPort }}
+      protocol: TCP
+      targetPort: {{ .Values.publicAPIPort }}
+  selector:
+    app: public-api
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -41,16 +56,3 @@ spec:
               value: {{ .Values.allowedOrigin }}
             - name: PUBLIC_API_ADDRESS
               value: :{{ .Values.publicAPIPort }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: public-api
-  labels:
-    app: public-api
-spec:
-  type: LoadBalancer
-  ports:
-    - port: {{ .Values.publicAPIPort }}
-  selector:
-    app: public-api

--- a/charts/web-frontend/templates/k8s.yaml
+++ b/charts/web-frontend/templates/k8s.yaml
@@ -3,15 +3,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name:  web-frontend
-  annotations:
-    external-dns.alpha.kubernetes.io/hostname: {{ .Values.domain }}
 spec:
-  type: LoadBalancer
+  type: NodePort
   selector:
       app: web-frontend
   ports:
     - port: 80
-      name: http
+      protocol: TCP
       targetPort: 80
 ---
 apiVersion: apps/v1

--- a/services/web-frontend/Dockerfile
+++ b/services/web-frontend/Dockerfile
@@ -6,9 +6,7 @@ COPY package*.json /app/
 RUN yarn install
 COPY ./ /app/
 
-# NOTE: This is the single value that must be updated.
-# process.env does not include container environment variables :-(
-RUN REACT_APP_API_PORT=":8000" yarn run build
+RUN yarn run build
 
 # Stage 1, based on Nginx, to have only the compiled app, ready for production with Nginx
 FROM nginx:1.18

--- a/services/web-frontend/src/App.tsx
+++ b/services/web-frontend/src/App.tsx
@@ -20,8 +20,7 @@ class App extends React.Component<any, StateType> {
   constructor(props: any) {
     super(props);
     // React App will only recognize environment variables with `REACT_APP_` prefix
-    const port = process.env.REACT_APP_API_PORT || ":8000";
-    const host = `${window.location.hostname}${port}`;
+    const host = `${window.location.hostname}`;
     const protocol = "http";
     this.state = {
       client: new Client(protocol, host),


### PR DESCRIPTION
## Terms
Ingress: rule set used by Ingress Controller for routing traffic. 
Ingress Controller: router. 

## What 
Makes ingress controller the first point of contact rather than the web-frontend. 

## How 
Install nginx controller and add two rules, one for routing public traffic to web-frontend and the other for public-api. 

## Why 
The first motivation for this change was the correctly route traffic from the web-frontend to public-api because the web-frontend was having trouble using public-api's DNS name for sending requests. 

The second motivation is that the ingress will come in handy for adding tls. 

## Tasks 

## Notes to Reviewers 

## Meta 